### PR TITLE
Linux 6.14-rc1 and f2fs-dev checkpoint io priority patch

### DIFF
--- a/drivers/gpu/drm/msm/dsi-staging/dsi_display.c
+++ b/drivers/gpu/drm/msm/dsi-staging/dsi_display.c
@@ -2078,6 +2078,10 @@ int dsi_display_dev_remove(struct platform_device *pdev)
 	}
 
 	display = platform_get_drvdata(pdev);
+	if (!display || !display->panel_node) {
+		DSI_ERR("invalid display\n");
+		return -EINVAL;
+	}
 
 	(void)_dsi_display_dev_deinit(display);
 

--- a/drivers/staging/qcacld-3.0/core/mac/src/sys/legacy/src/utils/src/dot11f.c
+++ b/drivers/staging/qcacld-3.0/core/mac/src/sys/legacy/src/utils/src/dot11f.c
@@ -134,7 +134,7 @@ typedef struct sIEDefn {
 #define DOT11F_PARAMETER_CHECK2(pSrc, pBuf, nBuf, pnConsumed) \
 	do { \
 		if (!pSrc || IsBadReadPtr(pSrc, 4))\
-			eturn DOT11F_BAD_INPUT_BUFFER; \
+			return DOT11F_BAD_INPUT_BUFFER; \
 		if (!pBuf || IsBadWritePtr(pBuf, nBuf))\
 			return DOT11F_BAD_OUTPUT_BUFFER; \
 		if (!nBuf)\

--- a/fs/f2fs/checkpoint.c
+++ b/fs/f2fs/checkpoint.c
@@ -20,7 +20,7 @@
 #include "segment.h"
 #include <trace/events/f2fs.h>
 
-#define DEFAULT_CHECKPOINT_IOPRIO (IOPRIO_PRIO_VALUE(IOPRIO_CLASS_BE, 3))
+#define DEFAULT_CHECKPOINT_IOPRIO (IOPRIO_PRIO_VALUE(IOPRIO_CLASS_RT, 3))
 
 static struct kmem_cache *ino_entry_slab;
 struct kmem_cache *f2fs_inode_entry_slab;

--- a/fs/f2fs/data.c
+++ b/fs/f2fs/data.c
@@ -1022,7 +1022,7 @@ struct page *f2fs_find_data_page(struct inode *inode, pgoff_t index)
 	struct address_space *mapping = inode->i_mapping;
 	struct page *page;
 
-	page = find_get_page(mapping, index);
+	page = find_get_page_flags(mapping, index, FGP_ACCESSED);
 	if (page && PageUptodate(page))
 		return page;
 	f2fs_put_page(page, 0);


### PR DESCRIPTION
1. f2fs: cache more dentry pages
https://github.com/torvalds/linux/commit/5f6594542779e69c6c6e2b57341c352174135eed
2. FROMGIT: f2fs: set highest IO priority for checkpoint thread
https://web.git.kernel.org/pub/scm/linux/kernel/git/jaegeuk/f2fs.git/commit/?h=dev-test&id=8a2d9f00d502e6ef68c6d52f0863856040ddd2db
